### PR TITLE
feat: implement basic CRUD with advanced querying

### DIFF
--- a/src/post/dto/create-post.dto.ts
+++ b/src/post/dto/create-post.dto.ts
@@ -1,1 +1,14 @@
-export class CreatePostDto {}
+import { IsArray, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreatePostDto {
+  @IsString()
+  title!: string;
+
+  @IsNumber()
+  authorId!: number;
+
+  @IsOptional()
+  @IsArray()
+  @IsNumber({}, { each: true })
+  tagIds?: number[];
+}

--- a/src/post/post.controller.spec.ts
+++ b/src/post/post.controller.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from '@mikro-orm/postgresql';
+
 import { PostController } from './post.controller';
 import { PostService } from './post.service';
 
@@ -8,7 +10,7 @@ describe('PostController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PostController],
-      providers: [PostService],
+      providers: [PostService, { provide: EntityManager, useValue: {} }],
     }).compile();
 
     controller = module.get<PostController>(PostController);

--- a/src/post/post.module.ts
+++ b/src/post/post.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
-import { PostService } from './post.service';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+
 import { PostController } from './post.controller';
+import { PostService } from './post.service';
+import { Post } from './entities/post.entity';
+import { Tag } from '../tag/entities/tag.entity';
+import { User } from '../user/entities/user.entity';
 
 @Module({
+  imports: [MikroOrmModule.forFeature([Post, Tag, User])],
   controllers: [PostController],
   providers: [PostService],
 })

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from '@mikro-orm/postgresql';
+
 import { PostService } from './post.service';
 
 describe('PostService', () => {
@@ -6,7 +8,7 @@ describe('PostService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PostService],
+      providers: [PostService, { provide: EntityManager, useValue: {} }],
     }).compile();
 
     service = module.get<PostService>(PostService);

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -1,27 +1,54 @@
 import { Injectable } from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/postgresql';
 
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { Post } from './entities/post.entity';
+import { Tag } from '../tag/entities/tag.entity';
+import { User } from '../user/entities/user.entity';
 
 @Injectable()
 export class PostService {
-  create(createPostDto: CreatePostDto) {
-    return 'This action adds a new post';
+  constructor(private readonly em: EntityManager) {}
+
+  async create(createPostDto: CreatePostDto) {
+    const post = this.em.create(Post, {
+      title: createPostDto.title,
+      author: this.em.getReference(User, createPostDto.authorId),
+      tags: createPostDto.tagIds?.map((id) => this.em.getReference(Tag, id)) ?? [],
+    });
+    await this.em.persistAndFlush(post);
+    return post;
   }
 
   findAll() {
-    return `This action returns all post`;
+    return this.em.find(Post, {}, { populate: ['author', 'tags'], orderBy: { title: 'asc' } });
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} post`;
+    return this.em.findOne(Post, id, { populate: ['author', 'tags'] });
   }
 
-  update(id: number, updatePostDto: UpdatePostDto) {
-    return `This action updates a #${id} post`;
+  async update(id: number, updatePostDto: UpdatePostDto) {
+    const post = await this.em.findOneOrFail(Post, id, { populate: ['tags'] });
+    if (updatePostDto.authorId) {
+      post.author = this.em.getReference(User, updatePostDto.authorId);
+    }
+    if (updatePostDto.tagIds) {
+      post.tags.removeAll();
+      const tags = updatePostDto.tagIds.map((id) =>
+        this.em.getReference(Tag, id),
+      );
+      tags.forEach((tag) => post.tags.add(tag));
+    }
+    this.em.assign(post, updatePostDto);
+    await this.em.flush();
+    return post;
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} post`;
+  async remove(id: number) {
+    const post = await this.em.findOneOrFail(Post, id);
+    await this.em.removeAndFlush(post);
+    return post;
   }
 }

--- a/src/tag/dto/create-tag.dto.ts
+++ b/src/tag/dto/create-tag.dto.ts
@@ -1,1 +1,6 @@
-export class CreateTagDto {}
+import { IsString } from 'class-validator';
+
+export class CreateTagDto {
+  @IsString()
+  name!: string;
+}

--- a/src/tag/tag.controller.spec.ts
+++ b/src/tag/tag.controller.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from '@mikro-orm/postgresql';
+
 import { TagController } from './tag.controller';
 import { TagService } from './tag.service';
 
@@ -8,7 +10,7 @@ describe('TagController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TagController],
-      providers: [TagService],
+      providers: [TagService, { provide: EntityManager, useValue: {} }],
     }).compile();
 
     controller = module.get<TagController>(TagController);

--- a/src/tag/tag.module.ts
+++ b/src/tag/tag.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
-import { TagService } from './tag.service';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+
 import { TagController } from './tag.controller';
+import { TagService } from './tag.service';
+import { Tag } from './entities/tag.entity';
+import { Post } from '../post/entities/post.entity';
 
 @Module({
+  imports: [MikroOrmModule.forFeature([Tag, Post])],
   controllers: [TagController],
   providers: [TagService],
 })

--- a/src/tag/tag.service.spec.ts
+++ b/src/tag/tag.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from '@mikro-orm/postgresql';
+
 import { TagService } from './tag.service';
 
 describe('TagService', () => {
@@ -6,7 +8,7 @@ describe('TagService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TagService],
+      providers: [TagService, { provide: EntityManager, useValue: {} }],
     }).compile();
 
     service = module.get<TagService>(TagService);

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -1,26 +1,38 @@
 import { Injectable } from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/postgresql';
+
 import { CreateTagDto } from './dto/create-tag.dto';
 import { UpdateTagDto } from './dto/update-tag.dto';
+import { Tag } from './entities/tag.entity';
 
 @Injectable()
 export class TagService {
-  create(createTagDto: CreateTagDto) {
-    return 'This action adds a new tag';
+  constructor(private readonly em: EntityManager) {}
+
+  async create(createTagDto: CreateTagDto) {
+    const tag = this.em.create(Tag, createTagDto);
+    await this.em.persistAndFlush(tag);
+    return tag;
   }
 
   findAll() {
-    return `This action returns all tag`;
+    return this.em.find(Tag, {}, { populate: ['posts', 'posts.author'] });
   }
 
   findOne(id: number) {
-    return `This action returns a #${id} tag`;
+    return this.em.findOne(Tag, id, { populate: ['posts', 'posts.author'] });
   }
 
-  update(id: number, updateTagDto: UpdateTagDto) {
-    return `This action updates a #${id} tag`;
+  async update(id: number, updateTagDto: UpdateTagDto) {
+    const tag = await this.em.findOneOrFail(Tag, id);
+    this.em.assign(tag, updateTagDto);
+    await this.em.flush();
+    return tag;
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} tag`;
+  async remove(id: number) {
+    const tag = await this.em.findOneOrFail(Tag, id);
+    await this.em.removeAndFlush(tag);
+    return tag;
   }
 }

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,1 +1,6 @@
-export class CreateUserDto {}
+import { IsString } from 'class-validator';
+
+export class CreateUserDto {
+  @IsString()
+  name!: string;
+}

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from '@mikro-orm/postgresql';
+
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 
@@ -8,7 +10,7 @@ describe('UserController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
-      providers: [UserService],
+      providers: [UserService, { provide: EntityManager, useValue: {} }],
     }).compile();
 
     controller = module.get<UserController>(UserController);

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
-import { UserService } from './user.service';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+
 import { UserController } from './user.controller';
+import { UserService } from './user.service';
+import { User } from './entities/user.entity';
 
 @Module({
+  imports: [MikroOrmModule.forFeature([User])],
   controllers: [UserController],
   providers: [UserService],
 })

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { EntityManager } from '@mikro-orm/postgresql';
+
 import { UserService } from './user.service';
 
 describe('UserService', () => {
@@ -6,7 +8,7 @@ describe('UserService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [UserService, { provide: EntityManager, useValue: {} }],
     }).compile();
 
     service = module.get<UserService>(UserService);


### PR DESCRIPTION
## Summary
- flesh out DTOs with validation for user, post, and tag
- implement MikroORM-based CRUD services with relation-populating read logic
- update modules and tests to wire EntityManager dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d4dfeca288321ac6d76e58db94e90