### PR TITLE
feat: add advanced post search

### DIFF
--- a/posts.http
+++ b/posts.http
@@ -1,20 +1,24 @@
 ### 전체 조회
-GET http://localhost:3000/posts
+GET http://localhost:3000/post
 
 ### 단건 조회
-GET http://localhost:3000/posts/1
+GET http://localhost:3000/post/1
+
+### 검색
+GET http://localhost:3000/post/search?title=Hello&authorName=John&tagNames=Nest&tagNames=JS
 
 ### 생성
-POST http://localhost:3000/posts
+POST http://localhost:3000/post
 Content-Type: application/json
 
 {
   "title": "Hello REST Client",
-  "content": "Testing NestJS CRUD with REST Client"
+  "authorId": 1,
+  "tagIds": [1, 2]
 }
 
 ### 수정
-PATCH http://localhost:3000/posts/1
+PATCH http://localhost:3000/post/1
 Content-Type: application/json
 
 {
@@ -22,4 +26,4 @@ Content-Type: application/json
 }
 
 ### 삭제
-DELETE http://localhost:3000/posts/1
+DELETE http://localhost:3000/post/1

--- a/src/post/dto/search-post.dto.ts
+++ b/src/post/dto/search-post.dto.ts
@@ -1,0 +1,18 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class SearchPostDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  authorName?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
+  @IsArray()
+  @IsString({ each: true })
+  tagNames?: string[];
+}

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { SearchPostDto } from './dto/search-post.dto';
 
 @Controller('post')
 export class PostController {
@@ -15,6 +16,11 @@ export class PostController {
   @Get()
   findAll() {
     return this.postService.findAll();
+  }
+
+  @Get('search')
+  search(@Query() query: SearchPostDto) {
+    return this.postService.search(query);
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- allow searching posts by multiple tag names
- document multi-tag search and valid create payload in posts.http

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_689d70859da88321939f05f6ba46e9f1