### PR TITLE
Fix bcrypt login validation and add tests

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,32 @@
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as bcrypt from 'bcrypt';
+
+import { UserService } from '../user/user.service';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let users: { findOneByName: jest.Mock };
+
+  beforeEach(async () => {
+    users = { findOneByName: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: JwtService, useValue: { sign: jest.fn() } },
+        { provide: UserService, useValue: users },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('validates a user with hashed password', async () => {
+    const password = 'secret';
+    const hashed = await bcrypt.hash(password, 10);
+    users.findOneByName.mockResolvedValue({ id: 1, name: 'test', password: hashed });
+
+    await expect(service.validateUser('test', password)).resolves.toEqual({ id: 1, name: 'test' });
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,7 @@
 // src/auth/auth.service.ts
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
 
 import { User } from '../user/entities/user.entity';
 import { UserService } from '../user/user.service';
@@ -17,10 +18,10 @@ export class AuthService {
     return this.jwt.sign(payload);
   }
 
-   async validateUser(username: string, pass: string): Promise<any> {
+  async validateUser(username: string, pass: string): Promise<any> {
     const user = await this.users.findOneByName(username);
-    if (user && user.password === pass) {
-      const { password, ...result } = user;
+    if (user && (await bcrypt.compare(pass, user.password))) {
+      const { password: _password, ...result } = user;
       return result;
     }
     return null;

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,6 +1,8 @@
+import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { User } from './entities/user.entity';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 
@@ -10,7 +12,11 @@ describe('UserController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
-      providers: [UserService, { provide: EntityManager, useValue: {} }],
+      providers: [
+        UserService,
+        { provide: EntityManager, useValue: {} },
+        { provide: getRepositoryToken(User), useValue: {} },
+      ],
     }).compile();
 
     controller = module.get<UserController>(UserController);

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,6 +1,8 @@
+import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { EntityManager } from '@mikro-orm/postgresql';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { User } from './entities/user.entity';
 import { UserService } from './user.service';
 
 describe('UserService', () => {
@@ -8,7 +10,11 @@ describe('UserService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService, { provide: EntityManager, useValue: {} }],
+      providers: [
+        UserService,
+        { provide: EntityManager, useValue: {} },
+        { provide: getRepositoryToken(User), useValue: {} },
+      ],
     }).compile();
 
     service = module.get<UserService>(UserService);


### PR DESCRIPTION
## Summary
- validate user credentials with bcrypt hashes during login
- add unit test for AuthService password validation
- mock MikroORM repository in user tests to satisfy dependencies

## Testing
- `npm test`
- `npm run lint` *(warnings: simple-import-sort in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a27b3a002c832190084288ad8ee264